### PR TITLE
Revert animation changes to fix bug.

### DIFF
--- a/src/FBX2glTF.h
+++ b/src/FBX2glTF.h
@@ -17,7 +17,7 @@
 #include <Windows.h>
 #endif
 
-#define FBX2GLTF_VERSION std::string("0.12.9")
+#define FBX2GLTF_VERSION std::string("0.13.0")
 
 #include <fmt/printf.h>
 

--- a/src/fbx/Fbx2Raw.cpp
+++ b/src/fbx/Fbx2Raw.cpp
@@ -762,6 +762,7 @@ static void ReadAnimations(RawModel& raw, FbxScene* pScene, const GltfOptions& o
       eMode = FbxTime::eFrames60;
       break;
   }
+  const double epsilon = 1e-5f;
 
   const int animationCount = pScene->GetSrcObjectCount<FbxAnimStack>();
   for (size_t animIx = 0; animIx < animationCount; animIx++) {
@@ -838,6 +839,10 @@ static void ReadAnimations(RawModel& raw, FbxScene* pScene, const GltfOptions& o
       const FbxVector4 baseTranslation = baseTransform.GetT();
       const FbxQuaternion baseRotation = baseTransform.GetQ();
       const FbxVector4 baseScaling = computeLocalScale(pNode);
+      bool hasTranslation = false;
+      bool hasRotation = false;
+      bool hasScale = false;
+      bool hasMorphs = false;
 
       RawChannel channel;
       channel.nodeIndex = raw.GetNodeById(pNode->GetUniqueID());
@@ -850,6 +855,20 @@ static void ReadAnimations(RawModel& raw, FbxScene* pScene, const GltfOptions& o
         const FbxVector4 localTranslation = localTransform.GetT();
         const FbxQuaternion localRotation = localTransform.GetQ();
         const FbxVector4 localScale = computeLocalScale(pNode, pTime);
+
+        hasTranslation |=
+            (fabs(localTranslation[0] - baseTranslation[0]) > epsilon ||
+             fabs(localTranslation[1] - baseTranslation[1]) > epsilon ||
+             fabs(localTranslation[2] - baseTranslation[2]) > epsilon);
+        hasRotation |=
+            (fabs(localRotation[0] - baseRotation[0]) > epsilon ||
+             fabs(localRotation[1] - baseRotation[1]) > epsilon ||
+             fabs(localRotation[2] - baseRotation[2]) > epsilon ||
+             fabs(localRotation[3] - baseRotation[3]) > epsilon);
+        hasScale |=
+            (fabs(localScale[0] - baseScaling[0]) > epsilon ||
+             fabs(localScale[1] - baseScaling[1]) > epsilon ||
+             fabs(localScale[2] - baseScaling[2]) > epsilon);
 
         channel.translations.push_back(toVec3f(localTranslation) * scaleFactor);
         channel.rotations.push_back(toQuatf(localRotation));
@@ -905,6 +924,7 @@ static void ReadAnimations(RawModel& raw, FbxScene* pScene, const GltfOptions& o
                 if (!std::isnan(result)) {
                   // we're transitioning into targetIx
                   channel.weights.push_back(result);
+                  hasMorphs = true;
                   continue;
                 }
                 if (targetIx != targetCount - 1) {
@@ -912,6 +932,7 @@ static void ReadAnimations(RawModel& raw, FbxScene* pScene, const GltfOptions& o
                   if (!std::isnan(result)) {
                     // we're transitioning AWAY from targetIx
                     channel.weights.push_back(1.0f - result);
+                    hasMorphs = true;
                     continue;
                   }
                 }
@@ -925,12 +946,27 @@ static void ReadAnimations(RawModel& raw, FbxScene* pScene, const GltfOptions& o
         }
       }
 
-      animation.channels.emplace_back(channel);
+      if (hasTranslation || hasRotation || hasScale || hasMorphs) {
+        if (!hasTranslation) {
+          channel.translations.clear();
+        }
+        if (!hasRotation) {
+          channel.rotations.clear();
+        }
+        if (!hasScale) {
+          channel.scales.clear();
+        }
+        if (!hasMorphs) {
+          channel.weights.clear();
+        }
 
-      totalSizeInBytes += channel.translations.size() * sizeof(channel.translations[0]) +
-          channel.rotations.size() * sizeof(channel.rotations[0]) +
-          channel.scales.size() * sizeof(channel.scales[0]) +
-          channel.weights.size() * sizeof(channel.weights[0]);
+        animation.channels.emplace_back(channel);
+
+        totalSizeInBytes += channel.translations.size() * sizeof(channel.translations[0]) +
+            channel.rotations.size() * sizeof(channel.rotations[0]) +
+            channel.scales.size() * sizeof(channel.scales[0]) +
+            channel.weights.size() * sizeof(channel.weights[0]);
+      }
 
       if (verboseOutput) {
         fmt::printf(


### PR DESCRIPTION
Fixes: https://github.com/V-Sekai/FBX2glTF/issues/16

@DavidRobb

Edited:

1. there's the animation optimization against epsilon this is a revert from Facebook (original)
2. the second is the pivot bake revert from Lyuma
3. Major version update
